### PR TITLE
Convert netlify-build script from CJS to ES module

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
+# Updated: Force fresh deploy
 [build]
     command = "npm ci && node scripts/netlify-build.cjs"
   functions = "netlify/functions"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
-# Updated: Force fresh deploy
+# Updated: Force fresh deploy - using ES module
 [build]
-    command = "npm ci && node scripts/netlify-build.cjs"
+    command = "npm ci && node scripts/netlify-build.js"
   functions = "netlify/functions"
   publish = "dist/spa"
 

--- a/scripts/netlify-build.js
+++ b/scripts/netlify-build.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+console.log("🚀 Starting Netlify build with environment variable setup...");
+
+// Function to read and parse .env file
+function readEnvFile(filename) {
+  const envPath = path.join(process.cwd(), filename);
+  if (fs.existsSync(envPath)) {
+    const content = fs.readFileSync(envPath, "utf8");
+    const lines = content.split("\n");
+    const env = {};
+
+    lines.forEach((line) => {
+      const trimmedLine = line.trim();
+      if (trimmedLine && !trimmedLine.startsWith("#")) {
+        const [key, ...valueParts] = trimmedLine.split("=");
+        if (key && valueParts.length > 0) {
+          env[key.trim()] = valueParts.join("=").trim();
+        }
+      }
+    });
+
+    return env;
+  }
+  return {};
+}
+
+// Read environment files
+const productionEnv = readEnvFile(".env.production");
+const fallbackEnv = readEnvFile(".env");
+
+// Merge environment variables (production takes precedence)
+const envVars = { ...fallbackEnv, ...productionEnv };
+
+// Set environment variables for build process
+Object.keys(envVars).forEach((key) => {
+  if (!process.env[key]) {
+    process.env[key] = envVars[key];
+    console.log(`✅ Set ${key}=${envVars[key].substring(0, 20)}...`);
+  } else {
+    console.log(`ℹ️  ${key} already set in environment`);
+  }
+});
+
+// Verify critical variables
+const criticalVars = ["VITE_SUPABASE_URL", "VITE_SUPABASE_ANON_KEY"];
+const missingVars = criticalVars.filter((varName) => !process.env[varName]);
+
+if (missingVars.length > 0) {
+  console.error("❌ Missing critical environment variables:", missingVars);
+  process.exit(1);
+}
+
+console.log("✅ Environment variables configured successfully");
+console.log("📦 Starting build process...");
+
+// Execute the actual build command
+try {
+  execSync("npm run build", {
+    stdio: "inherit",
+    env: { ...process.env },
+  });
+  console.log("🎉 Build completed successfully!");
+} catch (error) {
+  console.error("❌ Build failed:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
Updates the Netlify build configuration to use ES modules:

- Changed build command in netlify.toml from netlify-build.cjs to netlify-build.js
- Added comment indicating forced fresh deploy using ES module
- Created new netlify-build.js script with ES module syntax
- Script reads .env.production and .env files to set environment variables
- Validates critical variables (VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY)
- Executes npm run build with configured environment

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9840e27f9e844f628f3b14d570a7df0f/swoosh-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9840e27f9e844f628f3b14d570a7df0f</projectId>-->
<!--<branchName>swoosh-haven</branchName>-->