### PR TITLE
Add service categories for multi-service platform

### DIFF
--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -42,7 +42,7 @@ const navItems: NavItem[] = [
   },
   {
     id: "home",
-    label: "حلاقتي",
+    label: "الخدمات",
     icon: Home,
     roles: ["customer"],
   },

--- a/client/components/Layout.tsx
+++ b/client/components/Layout.tsx
@@ -145,7 +145,7 @@ export default function Layout({
             </div>
             <div className="flex flex-col">
               <h1 className="text-base sm:text-lg font-bold text-foreground">
-                حلاقة
+                خدماتي
               </h1>
               <LocationBar compact className="hidden sm:block" />
             </div>

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -383,7 +383,6 @@ class ApiClient {
         console.warn(`⏰ تم إلغاء الطلب أو انتهت المهلة: ${endpoint}`);
         console.warn("AbortError details:", {
           message: error.message,
-          cause: error.cause,
           stack: error.stack,
         });
 

--- a/client/lib/barber-cache.ts
+++ b/client/lib/barber-cache.ts
@@ -11,6 +11,7 @@ export interface CachedBarber {
   name: string;
   email: string;
   role: "barber";
+  service_category?: string; // New field for service categories
   status: string;
   level: number;
   points: number;

--- a/client/lib/store.ts
+++ b/client/lib/store.ts
@@ -299,7 +299,10 @@ export const appStore = new AppStore();
 
 // React Hook for using the store
 export function useAppStore(): [AppState, typeof appStore] {
-  const [state, setState] = useState(appStore.getState());
+  const [state, setState] = useState(() => {
+    // Use a function to lazily evaluate the initial state
+    return appStore.getState();
+  });
 
   useEffect(() => {
     const unsubscribe = appStore.subscribe(setState);

--- a/client/lib/store.ts
+++ b/client/lib/store.ts
@@ -309,5 +309,4 @@ export function useAppStore(): [AppState, typeof appStore] {
   return [state, appStore];
 }
 
-// Initialize auth on app start
-appStore.initializeAuth();
+// Note: Auth initialization is now handled in App component to avoid React hook issues

--- a/client/lib/store.ts
+++ b/client/lib/store.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import { User, Booking, Post, FriendRequest, Follow } from "@shared/api";
 import apiClient from "./api";
 

--- a/client/lib/store.ts
+++ b/client/lib/store.ts
@@ -299,6 +299,11 @@ export const appStore = new AppStore();
 
 // React Hook for using the store
 export function useAppStore(): [AppState, typeof appStore] {
+  // Add safety check for React context
+  if (typeof useState !== "function") {
+    throw new Error("useAppStore must be called within a React component");
+  }
+
   const [state, setState] = useState(appStore.getState());
 
   useEffect(() => {

--- a/client/lib/store.ts
+++ b/client/lib/store.ts
@@ -299,11 +299,6 @@ export const appStore = new AppStore();
 
 // React Hook for using the store
 export function useAppStore(): [AppState, typeof appStore] {
-  // Add safety check for React context
-  if (typeof useState !== "function") {
-    throw new Error("useAppStore must be called within a React component");
-  }
-
   const [state, setState] = useState(appStore.getState());
 
   useEffect(() => {

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -129,7 +129,7 @@ export default function Auth({ onAuth }: AuthProps) {
             break;
           case "INVALID_PASSWORD":
             errorMessage = "كلمة المرور غير صحيحة";
-            errorDetails = "تأكد من كتابة كلمة المرور الصحيحة";
+            errorDetails = "تأكد من كتابة كلمة ال��رور الصحيحة";
             break;
           case "ACCOUNT_BLOCKED":
             errorMessage = "تم حظر الحساب";
@@ -522,27 +522,70 @@ export default function Auth({ onAuth }: AuthProps) {
 
                     {registerData.role === "barber" && (
                       <div className="space-y-2">
-                        <Label htmlFor="activation-key">مفتاح التفعيل</Label>
-                        <Input
-                          id="activation-key"
-                          type="text"
-                          value={registerData.activation_key}
-                          onChange={(e) =>
+                        <Label htmlFor="service-category">فئة الخدمة</Label>
+                        <Select
+                          value={registerData.service_category || ""}
+                          onValueChange={(value: ServiceCategory) =>
                             setRegisterData((prev) => ({
                               ...prev,
-                              activation_key: e.target.value,
+                              service_category: value,
                             }))
                           }
-                          placeholder="أدخل مفتاح التفعيل المقدم من الإدارة"
-                          required
-                          className="text-right"
-                        />
+                        >
+                          <SelectTrigger className="text-right">
+                            <SelectValue placeholder="اختر فئة الخدمة" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {getAllServiceCategories().map((category) => {
+                              const config = getServiceCategoryConfig(
+                                category.id,
+                              );
+                              return (
+                                <SelectItem
+                                  key={category.id}
+                                  value={category.id}
+                                >
+                                  <div className="flex items-center gap-2">
+                                    <span className="text-lg">
+                                      {config.icon}
+                                    </span>
+                                    <span>{config.nameAr}</span>
+                                  </div>
+                                </SelectItem>
+                              );
+                            })}
+                          </SelectContent>
+                        </Select>
                         <p className="text-xs text-muted-foreground">
-                          للحصول على مفتاح التفعيل، تواصل مع الإدارة على
-                          WhatsApp: 07800657822
+                          اختر نوع الخدمة التي تقدمها
                         </p>
                       </div>
                     )}
+
+                    {registerData.role === "barber" &&
+                      registerData.service_category === "barber" && (
+                        <div className="space-y-2">
+                          <Label htmlFor="activation-key">مفتاح التفعيل</Label>
+                          <Input
+                            id="activation-key"
+                            type="text"
+                            value={registerData.activation_key}
+                            onChange={(e) =>
+                              setRegisterData((prev) => ({
+                                ...prev,
+                                activation_key: e.target.value,
+                              }))
+                            }
+                            placeholder="أدخل مفتاح التفعيل المقدم من الإدارة"
+                            required
+                            className="text-right"
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            للحصول على مفتاح التفعيل، تواصل مع الإدارة على
+                            WhatsApp: 07800657822
+                          </p>
+                        </div>
+                      )}
 
                     {error && (
                       <div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md border border-destructive/20">

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -105,7 +105,7 @@ export default function Auth({ onAuth }: AuthProps) {
         // استخدام الرسالة المخصصة من الخادم
         errorMessage = error.message;
 
-        // إضافة تفاصيل إضا��ية إذا كانت متوفرة
+        // إ��افة تفاصيل إضا��ية إذا كانت متوفرة
         const customError = error as any;
         if (customError.suggestion) {
           errorDetails = customError.suggestion;
@@ -188,11 +188,19 @@ export default function Auth({ onAuth }: AuthProps) {
       return;
     }
 
+    // Validate service category for service providers
+    if (registerData.role === "barber" && !registerData.service_category) {
+      setError("يرجى اختيار فئة الخدمة");
+      return;
+    }
+
+    // Legacy activation key validation for barbers only
     if (
       registerData.role === "barber" &&
+      registerData.service_category === "barber" &&
       !registerData.activation_key?.trim()
     ) {
-      setError("مفتاح التفعيل مطلوب لحسابات الحلاقين");
+      setError("مفتاح التفعيل مطلوب للحلاقين");
       return;
     }
 
@@ -232,7 +240,7 @@ export default function Auth({ onAuth }: AuthProps) {
             }
             break;
           case "NAME_TOO_SHORT":
-            errorMessage = "ا��اسم قصير جداً";
+            errorMessage = "الاسم قصير جداً";
             errorDetails = "يجب أن يحتوي الاسم على حرفين على الأقل";
             break;
           case "NAME_TOO_LONG":
@@ -252,7 +260,7 @@ export default function Auth({ onAuth }: AuthProps) {
             errorDetails = "يجب أن تحتوي على 6 أحرف على الأقل";
             break;
           case "MISSING_ACTIVATION_KEY":
-            errorMessage = "مفتاح التفعيل مطلوب للحلاقين";
+            errorMessage = "مفتاح التفعيل مطلوب للحلاقي��";
             errorDetails = "للحصول على مفتاح التفعيل اتصل: 07800657822";
             break;
           case "INVALID_ACTIVATION_KEY":
@@ -422,7 +430,7 @@ export default function Auth({ onAuth }: AuthProps) {
                   <CardHeader className="pb-4">
                     <CardTitle className="text-xl">إنشاء حساب جديد</CardTitle>
                     <CardDescription>
-                      أنشئ ��سابك وابدأ رحلتك معنا
+                      أنشئ حسابك وابدأ رحلتك معنا
                     </CardDescription>
                   </CardHeader>
 

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -129,7 +129,7 @@ export default function Auth({ onAuth }: AuthProps) {
             break;
           case "INVALID_PASSWORD":
             errorMessage = "كلمة المرور غير صحيحة";
-            errorDetails = "تأكد من كتابة كلمة ال��رور الصحيحة";
+            errorDetails = "تأكد من كتابة كلمة المرور الصحيحة";
             break;
           case "ACCOUNT_BLOCKED":
             errorMessage = "تم حظر الحساب";
@@ -173,7 +173,7 @@ export default function Auth({ onAuth }: AuthProps) {
     }
 
     if (registerData.name.trim().length < 2) {
-      setError("ال��سم يجب أن يحتوي على حرفين على الأقل");
+      setError("ال��سم يجب أن يحت��ي على حرفين على الأقل");
       return;
     }
 
@@ -244,7 +244,7 @@ export default function Auth({ onAuth }: AuthProps) {
             errorDetails = "يجب أن يحتوي الاسم على حرفين على الأقل";
             break;
           case "NAME_TOO_LONG":
-            errorMessage = "الاسم طو��ل جداً";
+            errorMessage = "الاسم طو���� جداً";
             errorDetails = "يجب أن يكون الاسم أقل من 50 حرف";
             break;
           case "INVALID_EMAIL_FORMAT":
@@ -336,9 +336,9 @@ export default function Auth({ onAuth }: AuthProps) {
             <div className="mx-auto w-16 h-16 bg-gradient-to-br from-primary to-golden-600 rounded-2xl flex items-center justify-center mb-4">
               <Scissors className="h-8 w-8 text-primary-foreground" />
             </div>
-            <h1 className="text-3xl font-bold text-foreground">حلاقة</h1>
+            <h1 className="text-3xl font-bold text-foreground">خدماتي</h1>
             <p className="text-muted-foreground mt-2">
-              نظام إدارة صالونات الحلاقة
+              نظام إدارة الخدمات المتعددة
             </p>
           </div>
 
@@ -581,7 +581,7 @@ export default function Auth({ onAuth }: AuthProps) {
                             className="text-right"
                           />
                           <p className="text-xs text-muted-foreground">
-                            للحصول على مفتاح التفعيل، تواصل مع الإدارة على
+                            للحصول على مفتاح التفعيل، تواصل م�� الإدارة على
                             WhatsApp: 07800657822
                           </p>
                         </div>

--- a/client/pages/Auth.tsx
+++ b/client/pages/Auth.tsx
@@ -20,6 +20,11 @@ import {
 } from "@/components/ui/select";
 import { Scissors, Sparkles, Crown } from "lucide-react";
 import { UserRole, LoginRequest, RegisterRequest } from "@shared/api";
+import {
+  ServiceCategory,
+  getAllServiceCategories,
+  getServiceCategoryConfig,
+} from "@shared/service-categories";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/lib/store";
 import LocationPermissionDialog from "@/components/LocationPermissionDialog";
@@ -50,7 +55,8 @@ export default function Auth({ onAuth }: AuthProps) {
     email: "",
     password: "",
     role: "customer",
-    activation_key: "",
+    service_category: undefined,
+    activation_key: "", // Keep for legacy barber support
   });
 
   const validateEmail = (email: string): boolean => {
@@ -226,7 +232,7 @@ export default function Auth({ onAuth }: AuthProps) {
             }
             break;
           case "NAME_TOO_SHORT":
-            errorMessage = "الاسم قصير جداً";
+            errorMessage = "ا��اسم قصير جداً";
             errorDetails = "يجب أن يحتوي الاسم على حرفين على الأقل";
             break;
           case "NAME_TOO_LONG":
@@ -416,7 +422,7 @@ export default function Auth({ onAuth }: AuthProps) {
                   <CardHeader className="pb-4">
                     <CardTitle className="text-xl">إنشاء حساب جديد</CardTitle>
                     <CardDescription>
-                      أنشئ حسابك وابدأ رحلتك معنا
+                      أنشئ ��سابك وابدأ رحلتك معنا
                     </CardDescription>
                   </CardHeader>
 

--- a/client/pages/BarberDashboard.tsx
+++ b/client/pages/BarberDashboard.tsx
@@ -25,6 +25,10 @@ import {
   FileImage,
 } from "lucide-react";
 import { User, Booking } from "@shared/api";
+import {
+  getUserDisplayRole,
+  getServiceCategoryIcon,
+} from "@shared/service-categories";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/lib/store";
 import apiClient from "@/lib/api";
@@ -267,7 +271,7 @@ export default function BarberDashboard({
           id: Date.now().toString(),
           type: "booking_accepted",
           title: "تم قبول الحجز",
-          message: `ت�� قبول حجز ${booking.user?.name || "العميل"}`,
+          message: `ت�� قبول حجز ${booking.user?.name || "ا��عميل"}`,
           data: booking,
           read: false,
           created_at: new Date().toISOString(),
@@ -778,7 +782,7 @@ export default function BarberDashboard({
                       id: Date.now().toString(),
                       type: "system",
                       title: "نوع ملف غير مدعوم",
-                      message: "يرجى اختيار صورة بصيغة JPG, PNG, GIF أو WebP",
+                      message: "يرجى اخت��ار صورة بصيغة JPG, PNG, GIF أو WebP",
                       data: null,
                       read: false,
                       created_at: new Date().toISOString(),
@@ -881,8 +885,14 @@ export default function BarberDashboard({
                 {user.email}
               </p>
               <div className="flex items-center gap-2 flex-wrap">
-                <Badge variant="outline" className="text-xs sm:text-sm">
-                  حلاق
+                <Badge
+                  variant="outline"
+                  className="text-xs sm:text-sm flex items-center gap-1"
+                >
+                  <span>
+                    {getServiceCategoryIcon(user.service_category || "barber")}
+                  </span>
+                  <span>{getUserDisplayRole(user)}</span>
                 </Badge>
                 <Badge className="bg-golden-500/10 text-golden-500 border-golden-500/20 text-xs sm:text-sm">
                   {getLevelIcon(user.level)} {getLevelLabel(user.level)}

--- a/client/pages/CustomerDashboard.tsx
+++ b/client/pages/CustomerDashboard.tsx
@@ -453,7 +453,7 @@ export default function CustomerDashboard({
       return;
     }
 
-    // إضافة طلب��ت صداقة تجريبية للإشعارات (مرة واحدة فقط)
+    // إضافة طلب��ت صداقة تجريبية للإشعارات (مرة واحدة ��قط)
     const friendRequests = [
       {
         id: "friend_req_1",
@@ -864,7 +864,7 @@ export default function CustomerDashboard({
 
   const loadProfileData = async () => {
     try {
-      // ت��ميل الإحصا��يات
+      // ت��ميل الإ��صا��يات
       const bookingsData = await apiClient.getBookings();
 
       // تحميل المتابعين والمتابعين
@@ -899,7 +899,7 @@ export default function CustomerDashboard({
     }
   };
 
-  // دالة مساعدة لإثراء بيانات المتابعة بمعلومات المستخدمين
+  // دالة مساعدة لإثراء بيانات المتابعة بمعلومات ال��ستخدمين
   const enrichFollowData = async (followData: any[], userIdField: string) => {
     if (!followData.length) return followData;
 
@@ -1099,7 +1099,7 @@ export default function CustomerDashboard({
       case "accepted":
         return "��ق��و��";
       case "rejected":
-        return "مرفوض";
+        return "م��فوض";
       case "cancelled":
         return "ملغي";
       default:
@@ -1574,6 +1574,21 @@ export default function CustomerDashboard({
       />
     );
   }
+
+  const handleServiceCategorySelect = (category: ServiceCategory) => {
+    setSelectedServiceCategory(category);
+    setShowServices(false); // Hide services page and show providers
+  };
+
+  const handleBackToServices = () => {
+    setSelectedServiceCategory(null);
+    setShowServices(true);
+  };
+
+  const handleBackToHome = () => {
+    setShowServices(false);
+    setSelectedServiceCategory(null);
+  };
 
   const renderHome = () => {
     const followedBarbers = filteredBarbers.filter(
@@ -2143,7 +2158,7 @@ export default function CustomerDashboard({
           </h3>
           <p className="text-muted-foreground">
             {exploreSearchQuery
-              ? "جر�� البحث بكلمة أخرى من المنشورات ال����يزة"
+              ? "جر�� البحث ��كلمة أخرى من المنشورات ال����يزة"
               : "لا توجد منشورات مميزة متا��ة حاليا��"}
           </p>
         </div>

--- a/client/pages/CustomerDashboard.tsx
+++ b/client/pages/CustomerDashboard.tsx
@@ -190,7 +190,7 @@ export default function CustomerDashboard({
         const followingResponse = await apiClient.getFollows("following");
         const follows = followingResponse.follows || [];
 
-        // تحديث store بب��انات المتابعة
+        // تحدي�� store بب��انات المتابعة
         store.setFollows(follows);
 
         console.log(`✅ Initialized ${follows.length} follows in store`);
@@ -453,7 +453,7 @@ export default function CustomerDashboard({
       return;
     }
 
-    // إضافة طلب��ت صداقة تجريبية للإشعارات (مرة واحدة ��قط)
+    // إضافة طلب��ت صداقة تجريبية للإشعارات (مرة واحدة فقط)
     const friendRequests = [
       {
         id: "friend_req_1",
@@ -864,7 +864,7 @@ export default function CustomerDashboard({
 
   const loadProfileData = async () => {
     try {
-      // ت��ميل الإ��صا��يات
+      // ت��ميل الإحصا��يات
       const bookingsData = await apiClient.getBookings();
 
       // تحميل المتابعين والمتابعين
@@ -876,7 +876,7 @@ export default function CustomerDashboard({
       const followersData = followersResponse.follows || [];
       const followingData = followingResponse.follows || [];
 
-      // تحميل بيانات المستخدمين الكاملة للمتابعين والمتابعين
+      // ت��ميل بيانات المستخدمين الكاملة للمتابعين والمتابعين
       const [enrichedFollowers, enrichedFollowing] = await Promise.all([
         enrichFollowData(followersData, "follower_id"),
         enrichFollowData(followingData, "followed_id"),
@@ -899,7 +899,7 @@ export default function CustomerDashboard({
     }
   };
 
-  // دالة مساعدة لإثراء بيانات المتابعة بمعلومات ال��ستخدمين
+  // دالة مساعدة لإثراء بيانات المتابعة بمعلومات المستخدمين
   const enrichFollowData = async (followData: any[], userIdField: string) => {
     if (!followData.length) return followData;
 
@@ -1099,7 +1099,7 @@ export default function CustomerDashboard({
       case "accepted":
         return "��ق��و��";
       case "rejected":
-        return "م��فوض";
+        return "مرفوض";
       case "cancelled":
         return "ملغي";
       default:
@@ -1591,6 +1591,36 @@ export default function CustomerDashboard({
   };
 
   const renderHome = () => {
+    // Show Services page instead of old barber list
+    return (
+      <ServicesPage
+        user={user}
+        onCategorySelect={handleServiceCategorySelect}
+        onBack={handleBackToHome}
+      />
+    );
+  };
+
+  // Show service providers for selected category
+  if (selectedServiceCategory) {
+    return (
+      <ServiceProvidersPage
+        user={user}
+        category={selectedServiceCategory}
+        onBack={handleBackToServices}
+        onProviderSelect={(provider) => {
+          setSelectedProfile(provider);
+          setShowProfile(true);
+        }}
+        onBookingRequest={(provider) => {
+          setSelectedBarber(provider);
+          setShowBookingPage(true);
+        }}
+      />
+    );
+  }
+
+  const renderOldHome = () => {
     const followedBarbers = filteredBarbers.filter(
       (barber) => barber.isFollowed,
     );
@@ -2158,7 +2188,7 @@ export default function CustomerDashboard({
           </h3>
           <p className="text-muted-foreground">
             {exploreSearchQuery
-              ? "جر�� البحث ��كلمة أخرى من المنشورات ال����يزة"
+              ? "جر�� البحث بكلمة أخرى من المنشورات ال����يزة"
               : "لا توجد منشورات مميزة متا��ة حاليا��"}
           </p>
         </div>

--- a/client/pages/CustomerDashboard.tsx
+++ b/client/pages/CustomerDashboard.tsx
@@ -53,6 +53,9 @@ import InstagramNewsFeed from "./InstagramNewsFeed";
 import AdvancedPostsFeed from "./AdvancedPostsFeed";
 import CreatePostDialog from "../components/CreatePostDialog";
 import ExplorePageWithTabs from "./ExplorePageWithTabs";
+import ServicesPage from "./ServicesPage";
+import ServiceProvidersPage from "./ServiceProvidersPage";
+import { ServiceCategory } from "@shared/service-categories";
 
 import LocationBar from "@/components/LocationBar";
 import { useLocation } from "@/hooks/use-location";
@@ -84,6 +87,9 @@ export default function CustomerDashboard({
   const [showFollowedBarbers, setShowFollowedBarbers] = useState(false);
   const [showNearbyBarbers, setShowNearbyBarbers] = useState(false);
   const [showAllBookings, setShowAllBookings] = useState(false);
+  const [showServices, setShowServices] = useState(false);
+  const [selectedServiceCategory, setSelectedServiceCategory] =
+    useState<ServiceCategory | null>(null);
 
   const [allBarbers, setAllBarbers] = useState<CachedBarber[]>([]);
   const [filteredBarbers, setFilteredBarbers] = useState<CachedBarber[]>([]);
@@ -466,7 +472,7 @@ export default function CustomerDashboard({
         id: "friend_req_2",
         type: "friend_request" as const,
         title: "طلب ص��اقة جديد",
-        message: "محمد العلي ي��يد متابعتك",
+        message: "محمد ا��علي ي��يد متابعتك",
         data: {
           senderId: "barber_2",
           senderName: "محمد العلي",
@@ -1589,7 +1595,7 @@ export default function CustomerDashboard({
                 <div className="flex items-center gap-2">
                   <div className="animate-spin h-3 w-3 border border-primary border-t-transparent rounded-full"></div>
                   <span className="text-sm text-primary">
-                    جاري ��حديد الموقع...
+                    جار�� ��حديد الموقع...
                   </span>
                 </div>
               ) : userLocation ? (
@@ -2446,7 +2452,7 @@ export default function CustomerDashboard({
                 <p className="text-2xl font-bold text-primary">
                   {profileStats.bookings}
                 </p>
-                <p className="text-sm text-muted-foreground">ح����وز��ت</p>
+                <p className="text-sm text-muted-foreground">ح�����وز��ت</p>
               </div>
               <div
                 className="cursor-pointer"

--- a/client/pages/ServiceProvidersPage.tsx
+++ b/client/pages/ServiceProvidersPage.tsx
@@ -79,7 +79,8 @@ export default function ServiceProvidersPage({
       const ultraCache = await getUltraFastBarberCache(user.id);
 
       // Get providers from cache
-      const cachedProviders = await ultraCache.getBarbers();
+      const cacheResult = await ultraCache.getInstantBarbers();
+      const cachedProviders = cacheResult.barbers;
       console.log(
         `✅ ULTRA-FAST: Loaded ${cachedProviders.length} ${category} providers from cache`,
       );
@@ -99,12 +100,13 @@ export default function ServiceProvidersPage({
         setFilteredProviders(categoryProviders);
         setProvidersFromCache(true);
 
-        // Background refresh
+        // Background refresh using preload
         setTimeout(async () => {
           try {
             console.log(`🔄 Background refresh for ${category} providers...`);
-            await ultraCache.refresh();
-            const refreshedProviders = await ultraCache.getBarbers();
+            await ultraCache.preloadOnLogin();
+            const refreshResult = await ultraCache.getInstantBarbers();
+            const refreshedProviders = refreshResult.barbers;
             const refreshedCategoryProviders =
               category === "barber"
                 ? refreshedProviders
@@ -125,10 +127,11 @@ export default function ServiceProvidersPage({
           }
         }, 1000);
       } else {
-        // No cache, force refresh
+        // No cache, force refresh using preload
         console.log(`📱 No cache found for ${category}, forcing refresh...`);
-        await ultraCache.refresh();
-        const freshProviders = await ultraCache.getBarbers();
+        await ultraCache.preloadOnLogin();
+        const freshResult = await ultraCache.getInstantBarbers();
+        const freshProviders = freshResult.barbers;
         const freshCategoryProviders =
           category === "barber"
             ? freshProviders
@@ -432,7 +435,7 @@ export default function ServiceProvidersPage({
               <p className="text-muted-foreground text-sm">
                 {searchQuery
                   ? `لم نجد أي ${categoryConfig.nameAr} يطابق "${searchQuery}"`
-                  : `سنقوم بإضا��ة ${categoryConfig.nameAr}ين في هذه المنطقة قريباً`}
+                  : `سنقوم بإضافة ${categoryConfig.nameAr}��ن في هذه المنطقة قريباً`}
               </p>
               {searchQuery && (
                 <Button

--- a/client/pages/ServiceProvidersPage.tsx
+++ b/client/pages/ServiceProvidersPage.tsx
@@ -1,0 +1,449 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Input } from "@/components/ui/input";
+import {
+  MapPin,
+  Star,
+  Clock,
+  Heart,
+  Search,
+  Filter,
+  Users,
+  Calendar,
+  ArrowLeft,
+} from "lucide-react";
+import { User, CreateBookingRequest } from "@shared/api";
+import {
+  ServiceCategory,
+  getServiceCategoryConfig,
+  getUserDisplayRole,
+} from "@shared/service-categories";
+import { cn } from "@/lib/utils";
+import { useAppStore } from "@/lib/store";
+import apiClient from "@/lib/api";
+import { getBarberCache, CachedBarber } from "@/lib/barber-cache";
+import { getUltraFastBarberCache } from "@/lib/ultra-fast-barber-cache";
+import { BarberSkeletonGrid } from "@/components/BarberSkeleton";
+import { UltraFastSkeletonGrid } from "@/components/UltraFastSkeleton";
+import { useLocation } from "@/hooks/use-location";
+
+interface ServiceProvidersPageProps {
+  user: User;
+  category: ServiceCategory;
+  onBack: () => void;
+  onProviderSelect: (provider: any) => void;
+  onBookingRequest: (provider: any) => void;
+}
+
+export default function ServiceProvidersPage({
+  user,
+  category,
+  onBack,
+  onProviderSelect,
+  onBookingRequest,
+}: ServiceProvidersPageProps) {
+  const [state, store] = useAppStore();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [allProviders, setAllProviders] = useState<CachedBarber[]>([]);
+  const [filteredProviders, setFilteredProviders] = useState<CachedBarber[]>(
+    [],
+  );
+  const [providersLoading, setProvidersLoading] = useState(true);
+  const [providersFromCache, setProvidersFromCache] = useState(false);
+  const [showSkeletons, setShowSkeletons] = useState(false);
+  const updateTimeoutRef = useRef<NodeJS.Timeout>();
+
+  const { userLocation, isLoadingLocation, requestLocation } = useLocation();
+  const categoryConfig = getServiceCategoryConfig(category);
+
+  // Ultra-fast provider loading (reusing barber loading logic for now)
+  const loadProvidersUltraFast = async () => {
+    const startTime = performance.now();
+    console.log(`ULTRA-FAST ${category} loading initiated for user:`, user?.id);
+
+    if (!user?.id) {
+      console.error("No user ID provided");
+      setProvidersLoading(false);
+      return;
+    }
+
+    try {
+      setShowSkeletons(true);
+      const ultraCache = await getUltraFastBarberCache(user.id);
+
+      // Get providers from cache
+      const cachedProviders = await ultraCache.getBarbers();
+      console.log(
+        `✅ ULTRA-FAST: Loaded ${cachedProviders.length} ${category} providers from cache`,
+      );
+
+      if (cachedProviders.length > 0) {
+        // Filter by category if needed (for now, only barbers are available)
+        const categoryProviders =
+          category === "barber"
+            ? cachedProviders
+            : cachedProviders.filter(
+                (provider) =>
+                  provider.service_category === category ||
+                  (category === "barber" && provider.role === "barber"),
+              );
+
+        setAllProviders(categoryProviders);
+        setFilteredProviders(categoryProviders);
+        setProvidersFromCache(true);
+
+        // Background refresh
+        setTimeout(async () => {
+          try {
+            console.log(`🔄 Background refresh for ${category} providers...`);
+            await ultraCache.refresh();
+            const refreshedProviders = await ultraCache.getBarbers();
+            const refreshedCategoryProviders =
+              category === "barber"
+                ? refreshedProviders
+                : refreshedProviders.filter(
+                    (provider) =>
+                      provider.service_category === category ||
+                      (category === "barber" && provider.role === "barber"),
+                  );
+
+            setAllProviders(refreshedCategoryProviders);
+            setFilteredProviders(refreshedCategoryProviders);
+            console.log(`✅ Background refresh completed for ${category}`);
+          } catch (error) {
+            console.warn(
+              `⚠️ Background refresh failed for ${category}:`,
+              error,
+            );
+          }
+        }, 1000);
+      } else {
+        // No cache, force refresh
+        console.log(`📱 No cache found for ${category}, forcing refresh...`);
+        await ultraCache.refresh();
+        const freshProviders = await ultraCache.getBarbers();
+        const freshCategoryProviders =
+          category === "barber"
+            ? freshProviders
+            : freshProviders.filter(
+                (provider) =>
+                  provider.service_category === category ||
+                  (category === "barber" && provider.role === "barber"),
+              );
+
+        setAllProviders(freshCategoryProviders);
+        setFilteredProviders(freshCategoryProviders);
+      }
+
+      const endTime = performance.now();
+      console.log(
+        `⚡ ULTRA-FAST ${category} loading completed in ${(endTime - startTime).toFixed(2)}ms`,
+      );
+    } catch (error) {
+      console.error(`❌ Error loading ${category} providers:`, error);
+      setAllProviders([]);
+      setFilteredProviders([]);
+    } finally {
+      setProvidersLoading(false);
+      setShowSkeletons(false);
+    }
+  };
+
+  useEffect(() => {
+    loadProvidersUltraFast();
+  }, [user?.id, category]);
+
+  // Search and filter logic
+  useEffect(() => {
+    if (!allProviders.length) return;
+
+    const filtered = allProviders.filter((provider) => {
+      const matchesSearch = provider.name
+        .toLowerCase()
+        .includes(searchQuery.toLowerCase());
+      return matchesSearch;
+    });
+
+    if (updateTimeoutRef.current) {
+      clearTimeout(updateTimeoutRef.current);
+    }
+
+    updateTimeoutRef.current = setTimeout(() => {
+      setFilteredProviders(filtered);
+    }, 100);
+
+    return () => {
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current);
+      }
+    };
+  }, [searchQuery, allProviders]);
+
+  const handleProviderClick = (provider: CachedBarber) => {
+    onProviderSelect(provider);
+  };
+
+  const handleBookProvider = (provider: CachedBarber) => {
+    onBookingRequest(provider);
+  };
+
+  const handleFollowProvider = async (providerId: string) => {
+    try {
+      await apiClient.followUser(providerId);
+
+      // Update local state
+      setAllProviders((prev) =>
+        prev.map((provider) =>
+          provider.id === providerId
+            ? { ...provider, isFollowed: true }
+            : provider,
+        ),
+      );
+      setFilteredProviders((prev) =>
+        prev.map((provider) =>
+          provider.id === providerId
+            ? { ...provider, isFollowed: true }
+            : provider,
+        ),
+      );
+
+      store.addNotification({
+        id: Date.now().toString(),
+        type: "friend_request",
+        title: "تمت المتابعة",
+        message: `بدأت بمتابعة ${filteredProviders.find((p) => p.id === providerId)?.name}`,
+        data: null,
+        read: false,
+        created_at: new Date().toISOString(),
+      });
+    } catch (error) {
+      console.error("Error following provider:", error);
+    }
+  };
+
+  const getLevelIcon = (level: number) => {
+    if (level >= 100) return "🟠";
+    if (level >= 51) return "🟡";
+    if (level >= 21) return "🔹";
+    return "🔸";
+  };
+
+  const getLevelLabel = (level: number) => {
+    if (level >= 100) return "VIP";
+    if (level >= 51) return "ذهبي";
+    if (level >= 21) return "محترف";
+    return "مبتدئ";
+  };
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "متاح":
+        return "bg-green-100 text-green-700 border-green-200";
+      case "مشغول":
+        return "bg-yellow-100 text-yellow-700 border-yellow-200";
+      case "غير متاح":
+        return "bg-red-100 text-red-700 border-red-200";
+      default:
+        return "bg-gray-100 text-gray-700 border-gray-200";
+    }
+  };
+
+  const formatDistance = (distance: number) => {
+    if (distance < 1) {
+      return `${(distance * 1000).toFixed(0)}م`;
+    }
+    return `${distance.toFixed(1)}كم`;
+  };
+
+  if (providersLoading && showSkeletons) {
+    return (
+      <div className="w-full max-w-full overflow-hidden">
+        {/* Header */}
+        <div className="sticky top-0 z-50 bg-card/80 backdrop-blur-md border-b border-border/50 px-4 py-3">
+          <div className="flex items-center gap-3">
+            <Button variant="ghost" size="icon" onClick={onBack}>
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+            <div className="flex items-center gap-2">
+              <span className="text-2xl">{categoryConfig.icon}</span>
+              <h1 className="text-base sm:text-lg font-bold text-foreground">
+                {categoryConfig.nameAr}
+              </h1>
+            </div>
+          </div>
+        </div>
+        <UltraFastSkeletonGrid />
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full max-w-full overflow-hidden">
+      {/* Header */}
+      <div className="sticky top-0 z-50 bg-card/80 backdrop-blur-md border-b border-border/50 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Button variant="ghost" size="icon" onClick={onBack}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <div className="flex items-center gap-2">
+            <span className="text-2xl">{categoryConfig.icon}</span>
+            <h1 className="text-base sm:text-lg font-bold text-foreground">
+              {categoryConfig.nameAr}
+            </h1>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-3 sm:p-4 space-y-4">
+        {/* Search Bar */}
+        <div className="relative">
+          <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder={`ابحث في ${categoryConfig.nameAr}...`}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pr-10 text-right"
+            dir="rtl"
+          />
+        </div>
+
+        {/* Results Count */}
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            {filteredProviders.length} من {categoryConfig.nameAr}
+            {filteredProviders.length !== 1 ? "ين" : ""}
+            {searchQuery && ` • نتائج البحث عن "${searchQuery}"`}
+          </p>
+          {providersFromCache && (
+            <Badge variant="outline" className="text-xs">
+              بيانات محفوظة
+            </Badge>
+          )}
+        </div>
+
+        {/* Providers Grid */}
+        {filteredProviders.length > 0 ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
+            {filteredProviders.map((provider) => (
+              <Card
+                key={provider.id}
+                className="border-border/50 bg-card/50 hover:bg-card/80 transition-all duration-200"
+              >
+                <CardContent className="p-4">
+                  <div className="flex items-start gap-3">
+                    <Avatar
+                      className="h-12 w-12 cursor-pointer hover:opacity-80 transition-opacity shrink-0"
+                      onClick={() => handleProviderClick(provider)}
+                    >
+                      <AvatarImage src={provider.avatar_url} />
+                      <AvatarFallback className="bg-primary/10 text-primary">
+                        {provider.name
+                          ? provider.name.charAt(0)
+                          : categoryConfig.icon}
+                      </AvatarFallback>
+                    </Avatar>
+
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <h4
+                          className="font-medium text-foreground cursor-pointer hover:text-primary transition-colors truncate"
+                          onClick={() => handleProviderClick(provider)}
+                        >
+                          {provider.name}
+                        </h4>
+                        <span className="text-sm">
+                          {getLevelIcon(provider.level)}
+                        </span>
+                        {provider.is_verified && (
+                          <div className="w-4 h-4 bg-blue-500 rounded-full flex items-center justify-center">
+                            <div className="w-2 h-2 bg-white rounded-full"></div>
+                          </div>
+                        )}
+                      </div>
+
+                      <p className="text-xs text-muted-foreground mb-2">
+                        {getUserDisplayRole(provider, category)}
+                      </p>
+
+                      <div className="flex items-center gap-3 text-xs text-muted-foreground mb-3">
+                        <div className="flex items-center gap-1">
+                          <Star className="h-3 w-3 fill-yellow-400 text-yellow-400" />
+                          <span>{provider.rating}</span>
+                        </div>
+                        {provider.distance && (
+                          <div className="flex items-center gap-1">
+                            <MapPin className="h-3 w-3" />
+                            <span>{formatDistance(provider.distance)}</span>
+                          </div>
+                        )}
+                        <Badge
+                          className={cn(
+                            "text-xs",
+                            getStatusColor(provider.status),
+                          )}
+                        >
+                          {provider.status}
+                        </Badge>
+                      </div>
+
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          className="flex-1 bg-primary hover:bg-primary/90 text-xs"
+                          onClick={() => handleBookProvider(provider)}
+                        >
+                          <Calendar className="h-3 w-3 mr-1" />
+                          احجز
+                        </Button>
+                        {!provider.isFollowed && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-xs px-3"
+                            onClick={() => handleFollowProvider(provider.id)}
+                          >
+                            <Heart className="h-3 w-3" />
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <Card className="border-border/50 bg-card/50">
+            <CardContent className="p-8 text-center">
+              <div className="text-4xl mb-4">{categoryConfig.icon}</div>
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                {searchQuery
+                  ? "لا توجد نتائج"
+                  : `لا يوجد ${categoryConfig.nameAr}ين متاحين`}
+              </h3>
+              <p className="text-muted-foreground text-sm">
+                {searchQuery
+                  ? `لم نجد أي ${categoryConfig.nameAr} يطابق "${searchQuery}"`
+                  : `سنقوم بإضافة ${categoryConfig.nameAr}ين في هذه المنطقة قريباً`}
+              </p>
+              {searchQuery && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-4"
+                  onClick={() => setSearchQuery("")}
+                >
+                  مسح البحث
+                </Button>
+              )}
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/pages/ServiceProvidersPage.tsx
+++ b/client/pages/ServiceProvidersPage.tsx
@@ -87,14 +87,17 @@ export default function ServiceProvidersPage({
 
       if (cachedProviders.length > 0) {
         // Filter by category if needed (for now, only barbers are available)
-        const categoryProviders =
-          category === "barber"
-            ? cachedProviders
-            : cachedProviders.filter(
-                (provider) =>
-                  provider.service_category === category ||
-                  (category === "barber" && provider.role === "barber"),
-              );
+        const categoryProviders = cachedProviders.filter((provider) => {
+          // For barber category, show all barbers (legacy and new)
+          if (category === "barber") {
+            return (
+              provider.role === "barber" ||
+              provider.service_category === "barber"
+            );
+          }
+          // For other categories, only show providers with matching service_category
+          return provider.service_category === category;
+        });
 
         setAllProviders(categoryProviders);
         setFilteredProviders(categoryProviders);
@@ -107,14 +110,17 @@ export default function ServiceProvidersPage({
             await ultraCache.preloadOnLogin();
             const refreshResult = await ultraCache.getInstantBarbers();
             const refreshedProviders = refreshResult.barbers;
-            const refreshedCategoryProviders =
-              category === "barber"
-                ? refreshedProviders
-                : refreshedProviders.filter(
-                    (provider) =>
-                      provider.service_category === category ||
-                      (category === "barber" && provider.role === "barber"),
+            const refreshedCategoryProviders = refreshedProviders.filter(
+              (provider) => {
+                if (category === "barber") {
+                  return (
+                    provider.role === "barber" ||
+                    provider.service_category === "barber"
                   );
+                }
+                return provider.service_category === category;
+              },
+            );
 
             setAllProviders(refreshedCategoryProviders);
             setFilteredProviders(refreshedCategoryProviders);
@@ -132,14 +138,15 @@ export default function ServiceProvidersPage({
         await ultraCache.preloadOnLogin();
         const freshResult = await ultraCache.getInstantBarbers();
         const freshProviders = freshResult.barbers;
-        const freshCategoryProviders =
-          category === "barber"
-            ? freshProviders
-            : freshProviders.filter(
-                (provider) =>
-                  provider.service_category === category ||
-                  (category === "barber" && provider.role === "barber"),
-              );
+        const freshCategoryProviders = freshProviders.filter((provider) => {
+          if (category === "barber") {
+            return (
+              provider.role === "barber" ||
+              provider.service_category === "barber"
+            );
+          }
+          return provider.service_category === category;
+        });
 
         setAllProviders(freshCategoryProviders);
         setFilteredProviders(freshCategoryProviders);
@@ -321,7 +328,7 @@ export default function ServiceProvidersPage({
         {/* Results Count */}
         <div className="flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            {filteredProviders.length} من {categoryConfig.nameAr}
+            {filteredProviders.length} م�� {categoryConfig.nameAr}
             {filteredProviders.length !== 1 ? "ين" : ""}
             {searchQuery && ` • نتائج البحث عن "${searchQuery}"`}
           </p>
@@ -435,7 +442,7 @@ export default function ServiceProvidersPage({
               <p className="text-muted-foreground text-sm">
                 {searchQuery
                   ? `لم نجد أي ${categoryConfig.nameAr} يطابق "${searchQuery}"`
-                  : `سنقوم بإضافة ${categoryConfig.nameAr}��ن في هذه المنطقة قريباً`}
+                  : `سنقوم بإضافة ${categoryConfig.nameAr}ين في هذه المنطقة قريباً`}
               </p>
               {searchQuery && (
                 <Button

--- a/client/pages/ServiceProvidersPage.tsx
+++ b/client/pages/ServiceProvidersPage.tsx
@@ -56,7 +56,11 @@ export default function ServiceProvidersPage({
   const [showSkeletons, setShowSkeletons] = useState(false);
   const updateTimeoutRef = useRef<NodeJS.Timeout>();
 
-  const { userLocation, isLoadingLocation, requestLocation } = useLocation();
+  const {
+    location: userLocation,
+    isLoading: isLoadingLocation,
+    requestLocation,
+  } = useLocation();
   const categoryConfig = getServiceCategoryConfig(category);
 
   // Ultra-fast provider loading (reusing barber loading logic for now)
@@ -428,7 +432,7 @@ export default function ServiceProvidersPage({
               <p className="text-muted-foreground text-sm">
                 {searchQuery
                   ? `لم نجد أي ${categoryConfig.nameAr} يطابق "${searchQuery}"`
-                  : `سنقوم بإضافة ${categoryConfig.nameAr}ين في هذه المنطقة قريباً`}
+                  : `سنقوم بإضا��ة ${categoryConfig.nameAr}ين في هذه المنطقة قريباً`}
               </p>
               {searchQuery && (
                 <Button

--- a/client/pages/ServicesPage.tsx
+++ b/client/pages/ServicesPage.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ArrowRight, Users, Star, MapPin } from "lucide-react";
+import { User } from "@shared/api";
+import {
+  ServiceCategory,
+  getAllServiceCategories,
+  getServiceCategoryConfig,
+} from "@shared/service-categories";
+import { cn } from "@/lib/utils";
+
+interface ServicesPageProps {
+  user: User;
+  onCategorySelect: (category: ServiceCategory) => void;
+  onBack?: () => void;
+}
+
+export default function ServicesPage({
+  user,
+  onCategorySelect,
+  onBack,
+}: ServicesPageProps) {
+  const [selectedCategory, setSelectedCategory] =
+    useState<ServiceCategory | null>(null);
+
+  const serviceCategories = getAllServiceCategories();
+
+  const handleCategoryClick = (category: ServiceCategory) => {
+    setSelectedCategory(category);
+    onCategorySelect(category);
+  };
+
+  if (selectedCategory) {
+    // This will be handled by parent component routing
+    return null;
+  }
+
+  return (
+    <div className="w-full max-w-full overflow-hidden p-3 sm:p-4 space-y-4 sm:space-y-6">
+      {/* Header */}
+      <div className="text-center py-4 sm:py-6">
+        <h2 className="text-xl sm:text-2xl font-bold text-foreground mb-2">
+          اختر نوع الخدمة
+        </h2>
+        <p className="text-sm sm:text-base text-muted-foreground">
+          تصفح جميع مقدمي الخدمات حسب التخصص
+        </p>
+      </div>
+
+      {/* Service Categories Grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
+        {serviceCategories.map((category) => {
+          const config = getServiceCategoryConfig(category.id);
+
+          return (
+            <Card
+              key={category.id}
+              className="border-border/50 bg-card/50 hover:bg-card/80 transition-all duration-200 cursor-pointer group hover:border-primary/20 hover:shadow-lg"
+              onClick={() => handleCategoryClick(category.id)}
+            >
+              <CardContent className="p-6">
+                <div className="flex items-center gap-4 mb-4">
+                  {/* Category Icon */}
+                  <div
+                    className={cn(
+                      "w-12 h-12 rounded-xl flex items-center justify-center text-2xl",
+                      config.gradient,
+                      "text-white shadow-lg",
+                    )}
+                  >
+                    {config.icon}
+                  </div>
+
+                  {/* Category Info */}
+                  <div className="flex-1">
+                    <h3 className="text-lg font-bold text-foreground mb-1">
+                      {config.nameAr}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {config.description}
+                    </p>
+                  </div>
+
+                  {/* Arrow Icon */}
+                  <ArrowRight className="h-5 w-5 text-muted-foreground group-hover:text-primary group-hover:translate-x-1 transition-all" />
+                </div>
+
+                {/* Category Stats */}
+                <div className="flex items-center justify-between text-sm">
+                  <div className="flex items-center gap-4">
+                    <div className="flex items-center gap-1">
+                      <Users className="h-4 w-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">
+                        {category.id === "barber" ? "12" : "قريباً"} مقدم خدمة
+                      </span>
+                    </div>
+                    {category.id === "barber" && (
+                      <div className="flex items-center gap-1">
+                        <Star className="h-4 w-4 text-yellow-500 fill-yellow-500" />
+                        <span className="text-muted-foreground">4.8</span>
+                      </div>
+                    )}
+                  </div>
+
+                  {category.id === "barber" ? (
+                    <Badge className="bg-green-100 text-green-700 border-green-200">
+                      متاح
+                    </Badge>
+                  ) : (
+                    <Badge variant="outline" className="text-muted-foreground">
+                      قريباً
+                    </Badge>
+                  )}
+                </div>
+
+                {/* Specializations Preview */}
+                <div className="mt-3 pt-3 border-t border-border/50">
+                  <p className="text-xs text-muted-foreground">
+                    <span className="font-medium">التخصصات:</span>{" "}
+                    {config.fields.specialization}
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Coming Soon Notice */}
+      <Card className="border-border/50 bg-gradient-to-r from-primary/5 to-golden-500/5 border-primary/20">
+        <CardContent className="p-4 text-center">
+          <h4 className="font-semibold text-foreground mb-2">
+            خدمات أكثر قريباً!
+          </h4>
+          <p className="text-sm text-muted-foreground mb-3">
+            نعمل على إضافة المزيد من أنواع الخدمات لتلبية احتياجاتك
+          </p>
+          <div className="flex items-center justify-center gap-2 text-xs text-primary">
+            <MapPin className="h-3 w-3" />
+            <span>في منطقتك</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Quick Stats */}
+      <div className="grid grid-cols-3 gap-3 text-center">
+        <div className="p-3 bg-card/30 rounded-lg">
+          <p className="text-lg font-bold text-primary">12</p>
+          <p className="text-xs text-muted-foreground">مقدم خدمة</p>
+        </div>
+        <div className="p-3 bg-card/30 rounded-lg">
+          <p className="text-lg font-bold text-primary">4.8</p>
+          <p className="text-xs text-muted-foreground">تقييم عام</p>
+        </div>
+        <div className="p-3 bg-card/30 rounded-lg">
+          <p className="text-lg font-bold text-primary">24/7</p>
+          <p className="text-xs text-muted-foreground">خدمة متاحة</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/pages/UserProfile.tsx
+++ b/client/pages/UserProfile.tsx
@@ -479,7 +479,7 @@ export default function UserProfile({
         </Card>
 
         {/* Content Tabs */}
-        {profileUser.role === "barber" && (
+        {(profileUser.role === "barber" || profileUser.service_category) && (
           <Tabs value={activeTab} onValueChange={setActiveTab}>
             <TabsList className="grid w-full grid-cols-2">
               <TabsTrigger value="posts">المنشورات</TabsTrigger>

--- a/client/pages/UserProfile.tsx
+++ b/client/pages/UserProfile.tsx
@@ -18,6 +18,10 @@ import {
   MessageCircle,
 } from "lucide-react";
 import { User } from "@shared/api";
+import {
+  getUserDisplayRole,
+  getServiceCategoryIcon,
+} from "@shared/service-categories";
 import { cn } from "@/lib/utils";
 import { useAppStore } from "@/lib/store";
 import apiClient from "@/lib/api";
@@ -361,8 +365,15 @@ export default function UserProfile({
           </Button>
           <div className="flex-1">
             <h1 className="font-bold text-lg">{profileUser.name}</h1>
-            <p className="text-sm text-muted-foreground">
-              {profileUser.role === "barber" ? "حلاق" : "عميل"}
+            <p className="text-sm text-muted-foreground flex items-center gap-1">
+              <span>
+                {profileUser.role === "barber"
+                  ? getServiceCategoryIcon(
+                      profileUser.service_category || "barber",
+                    )
+                  : "👤"}
+              </span>
+              <span>{getUserDisplayRole(profileUser)}</span>
             </p>
           </div>
         </div>

--- a/client/pages/UserProfile.tsx
+++ b/client/pages/UserProfile.tsx
@@ -461,8 +461,9 @@ export default function UserProfile({
                   </Button>
                 </div>
 
-                {/* الصف الثاني: حجز موعد (للحلاقين فقط) */}
-                {profileUser.role === "barber" && (
+                {/* الصف الثاني: حجز موعد (لمقدمي الخدمات) */}
+                {(profileUser.role === "barber" ||
+                  profileUser.service_category) && (
                   <Button
                     variant="outline"
                     onClick={onBooking}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -321,15 +321,16 @@ export const handleRegister: RequestHandler = async (req, res) => {
         email: email.toLowerCase().trim(),
         password_hash,
         role,
+        service_category: role === "barber" ? service_category : undefined,
         status: "active",
         level: 1,
         points: 0,
-        is_verified: role === "customer", // Barbers might need manual verification
+        is_verified: role === "customer", // Service providers might need manual verification
       });
     } catch (createError) {
       console.error("User creation error:", createError);
       return res.status(500).json({
-        error: "خطأ في إنشاء الحساب، يرجى المحاولة مرة أخرى",
+        error: "خطأ في إنشاء الحساب، يرجى المحا��لة مرة أخرى",
         errorType: "USER_CREATION_ERROR",
       });
     }
@@ -404,7 +405,7 @@ export const handleRegister: RequestHandler = async (req, res) => {
         dbError.message?.includes("network")
       ) {
         return res.status(500).json({
-          error: "خطأ في الاتصال بقاعدة البيانات، يرجى المحاولة مرة أخرى",
+          error: "خطأ في الاتصال بقاعدة البيانات، ير��ى المحاولة مرة أخرى",
           errorType: "DATABASE_CONNECTION_ERROR",
         });
       }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -116,13 +116,20 @@ export const handleLogin: RequestHandler = async (req, res) => {
 
 export const handleRegister: RequestHandler = async (req, res) => {
   try {
-    const { name, email, password, role, activation_key }: RegisterRequest =
-      req.body;
+    const {
+      name,
+      email,
+      password,
+      role,
+      service_category,
+      activation_key,
+    }: RegisterRequest = req.body;
 
     console.log("Registration attempt:", {
       name,
       email,
       role,
+      service_category,
       hasActivationKey: !!activation_key,
       timestamp: new Date().toISOString(),
     });
@@ -238,11 +245,22 @@ export const handleRegister: RequestHandler = async (req, res) => {
       });
     }
 
-    // For barbers, validate activation key
+    // For service providers, validate service category
     if (role === "barber") {
-      if (!activation_key || !activation_key.trim()) {
+      if (!service_category) {
         return res.status(400).json({
-          error: "مفتاح التفعيل مطلوب لإنشاء حساب حلاق",
+          error: "يرجى اختيار فئة الخدمة",
+          errorType: "MISSING_SERVICE_CATEGORY",
+        });
+      }
+
+      // Legacy activation key validation for barbers only
+      if (
+        service_category === "barber" &&
+        (!activation_key || !activation_key.trim())
+      ) {
+        return res.status(400).json({
+          error: "مفتاح التفعيل مطلوب للحلاقين",
           errorType: "MISSING_ACTIVATION_KEY",
           suggestion: "للحصول على مفتاح التفعيل، اتصل على: 07800657822",
         });
@@ -364,7 +382,7 @@ export const handleRegister: RequestHandler = async (req, res) => {
         return res.status(409).json({
           error: "هذا البريد الإلكتروني مسجل مسبقاً في النظام",
           errorType: "DUPLICATE_EMAIL",
-          suggestion: "استخدم بريد إلكتروني آخر أو سجل الدخول بالبريد الموجود",
+          suggestion: "استخدم بريد إلكتر��ني آخر أو سجل الدخول بالبريد الموجود",
         });
       }
 

--- a/server/routes/barbershop.ts
+++ b/server/routes/barbershop.ts
@@ -420,7 +420,7 @@ export const debugFollows: RequestHandler = async (req, res) => {
             createdAt: f.created_at,
           })) || [],
       };
-      result.autoFixed = true;
+      (result as any).autoFixed = true;
     }
 
     res.json(result);

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -2,6 +2,9 @@ export interface DemoResponse {
   message: string;
 }
 
+// Import service categories
+import { ServiceCategory } from "./service-categories";
+
 // User roles
 export type UserRole = "customer" | "barber" | "admin";
 
@@ -28,6 +31,7 @@ export interface User {
   level: number;
   points: number;
   is_verified: boolean;
+  service_category?: ServiceCategory; // New field for service providers
   location?: {
     lat: number;
     lng: number;
@@ -54,7 +58,8 @@ export interface RegisterRequest {
   email: string;
   password: string;
   role: UserRole;
-  activation_key?: string; // Required for barbers
+  service_category?: ServiceCategory; // Required for service providers
+  activation_key?: string; // Required for barbers (legacy)
 }
 
 export interface AuthResponse {

--- a/shared/database.ts
+++ b/shared/database.ts
@@ -1,6 +1,8 @@
 // Database Schema Types for Supabase Integration
 // This file defines the exact structure expected by Supabase
 
+import { ServiceCategory } from "./service-categories";
+
 export interface Database {
   public: {
     Tables: {
@@ -13,6 +15,7 @@ export interface Database {
           avatar_url?: string;
           phone?: string;
           role: "customer" | "barber" | "admin";
+          service_category?: ServiceCategory;
           status: "active" | "pending" | "blocked";
           level: number;
           points: number;
@@ -33,6 +36,7 @@ export interface Database {
           avatar_url?: string;
           phone?: string;
           role: "customer" | "barber" | "admin";
+          service_category?: ServiceCategory;
           status?: "active" | "pending" | "blocked";
           level?: number;
           points?: number;
@@ -48,6 +52,7 @@ export interface Database {
         Update: {
           name?: string;
           email?: string;
+          service_category?: ServiceCategory;
           password_hash?: string;
           avatar_url?: string;
           phone?: string;

--- a/shared/service-categories.ts
+++ b/shared/service-categories.ts
@@ -1,0 +1,157 @@
+export type ServiceCategory =
+  | "barber"
+  | "doctor"
+  | "engineer"
+  | "teacher"
+  | "chef";
+
+export interface ServiceCategoryConfig {
+  id: ServiceCategory;
+  nameAr: string;
+  nameEn: string;
+  icon: string;
+  color: string;
+  gradient: string;
+  description: string;
+  fields: {
+    profession: string;
+    specialization?: string;
+    workplace?: string;
+  };
+}
+
+export const SERVICE_CATEGORIES: Record<
+  ServiceCategory,
+  ServiceCategoryConfig
+> = {
+  barber: {
+    id: "barber",
+    nameAr: "حلاق",
+    nameEn: "Barber",
+    icon: "✂️",
+    color: "from-amber-500 to-orange-600",
+    gradient: "bg-gradient-to-br from-amber-500 to-orange-600",
+    description: "خدمات الحلاقة و��لعناية بالشعر",
+    fields: {
+      profession: "حلاق",
+      specialization: "حلاقة كلاسيكية، حلاقة عصرية، تشذيب اللحية",
+      workplace: "صالون حلاقة",
+    },
+  },
+  doctor: {
+    id: "doctor",
+    nameAr: "طبيب",
+    nameEn: "Doctor",
+    icon: "🩺",
+    color: "from-blue-500 to-cyan-600",
+    gradient: "bg-gradient-to-br from-blue-500 to-cyan-600",
+    description: "الخدمات الطبية والرعاية الصحية",
+    fields: {
+      profession: "طبيب",
+      specialization: "طب عام، أسنان، جلدية، أطفال",
+      workplace: "مستشفى، عيادة خاصة",
+    },
+  },
+  engineer: {
+    id: "engineer",
+    nameAr: "مهندس",
+    nameEn: "Engineer",
+    icon: "⚙️",
+    color: "from-green-500 to-emerald-600",
+    gradient: "bg-gradient-to-br from-green-500 to-emerald-600",
+    description: "الخدمات الهندسية والتقنية",
+    fields: {
+      profession: "مهندس",
+      specialization: "مدني، كهرباء، ميكانيكا، برمجيات",
+      workplace: "شركة هندسية، مكتب استشاري",
+    },
+  },
+  teacher: {
+    id: "teacher",
+    nameAr: "معلم",
+    nameEn: "Teacher",
+    icon: "📚",
+    color: "from-purple-500 to-violet-600",
+    gradient: "bg-gradient-to-br from-purple-500 to-violet-600",
+    description: "الخدمات التعليمية والتدريس",
+    fields: {
+      profession: "معلم",
+      specialization: "رياضيات، علوم، لغة عربية، إنجليزية",
+      workplace: "مدرسة، مركز تعليمي",
+    },
+  },
+  chef: {
+    id: "chef",
+    nameAr: "طباخ",
+    nameEn: "Chef",
+    icon: "👨‍🍳",
+    color: "from-red-500 to-pink-600",
+    gradient: "bg-gradient-to-br from-red-500 to-pink-600",
+    description: "خدمات الطبخ والضيافة",
+    fields: {
+      profession: "طباخ",
+      specialization: "مأكولات شرقية، غربية، حلويات",
+      workplace: "مطعم، فندق، منزل",
+    },
+  },
+};
+
+export const getServiceCategoryConfig = (
+  category: ServiceCategory,
+): ServiceCategoryConfig => {
+  return SERVICE_CATEGORIES[category];
+};
+
+export const getAllServiceCategories = (): ServiceCategoryConfig[] => {
+  return Object.values(SERVICE_CATEGORIES);
+};
+
+export const getServiceCategoryName = (category: ServiceCategory): string => {
+  return SERVICE_CATEGORIES[category]?.nameAr || category;
+};
+
+export const getServiceCategoryIcon = (category: ServiceCategory): string => {
+  return SERVICE_CATEGORIES[category]?.icon || "👤";
+};
+
+export const getServiceCategoryColor = (category: ServiceCategory): string => {
+  return SERVICE_CATEGORIES[category]?.color || "from-gray-500 to-gray-600";
+};
+
+// Map legacy barber role to new service category system
+export const mapUserRoleToServiceCategory = (role: string): ServiceCategory => {
+  switch (role) {
+    case "barber":
+      return "barber";
+    default:
+      return "barber"; // Default fallback
+  }
+};
+
+// Get user's display role based on service category
+export const getUserDisplayRole = (
+  user: User,
+  serviceCategory?: ServiceCategory,
+): string => {
+  // If user has service_category field, use it
+  if ("service_category" in user && user.service_category) {
+    return getServiceCategoryName(user.service_category as ServiceCategory);
+  }
+
+  // If serviceCategory is provided, use it
+  if (serviceCategory) {
+    return getServiceCategoryName(serviceCategory);
+  }
+
+  // Fallback to legacy role mapping
+  switch (user.role) {
+    case "barber":
+      return "حلاق";
+    case "customer":
+      return "زبون";
+    case "admin":
+      return "مدير";
+    default:
+      return user.role;
+  }
+};

--- a/shared/service-categories.ts
+++ b/shared/service-categories.ts
@@ -31,7 +31,7 @@ export const SERVICE_CATEGORIES: Record<
     icon: "✂️",
     color: "from-amber-500 to-orange-600",
     gradient: "bg-gradient-to-br from-amber-500 to-orange-600",
-    description: "خدمات الحلاقة و��لعناية بالشعر",
+    description: "خدمات الحلاقة والعناية بالشعر",
     fields: {
       profession: "حلاق",
       specialization: "حلاقة كلاسيكية، حلاقة عصرية، تشذيب اللحية",
@@ -45,7 +45,7 @@ export const SERVICE_CATEGORIES: Record<
     icon: "🩺",
     color: "from-blue-500 to-cyan-600",
     gradient: "bg-gradient-to-br from-blue-500 to-cyan-600",
-    description: "الخدمات الطبية والرعاية الصحية",
+    description: "��لخدمات الطبية والرعاية الصحية",
     fields: {
       profession: "طبيب",
       specialization: "طب عام، أسنان، جلدية، أطفال",
@@ -82,7 +82,7 @@ export const SERVICE_CATEGORIES: Record<
   },
   chef: {
     id: "chef",
-    nameAr: "طباخ",
+    nameAr: "ط��اخ",
     nameEn: "Chef",
     icon: "👨‍🍳",
     color: "from-red-500 to-pink-600",
@@ -130,7 +130,7 @@ export const mapUserRoleToServiceCategory = (role: string): ServiceCategory => {
 
 // Get user's display role based on service category
 export const getUserDisplayRole = (
-  user: User,
+  user: any, // User type will be imported where needed
   serviceCategory?: ServiceCategory,
 ): string => {
   // If user has service_category field, use it


### PR DESCRIPTION
This pull request introduces a service category system to expand the platform beyond barber services to support multiple service types.

**Changes made:**

- Added new `service-categories.ts` shared module with 5 service types: barber, doctor, engineer, teacher, chef
- Updated user registration to include service category selection for service providers
- Modified database schema to include `service_category` field in users table
- Updated UI labels from "حلاقة" to "خدماتي" and "حلاقتي" to "الخدمات" to reflect multi-service nature
- Enhanced registration form with service category dropdown for barbers
- Made activation key required only for barber category (legacy support)
- Added service category field to cached barber interface
- Improved store initialization to avoid React hook issues
- Fixed import statement in store.ts to include React
- Removed error.cause logging in API client
- Fixed TypeScript type assertion in barbershop routes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 32`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6bae55722fba47a8a8c99690da2aba17/neon-hub)

👀 [Preview Link](https://6bae55722fba47a8a8c99690da2aba17-neon-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6bae55722fba47a8a8c99690da2aba17</projectId>-->
<!--<branchName>neon-hub</branchName>-->